### PR TITLE
Updated cracks to version 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "chai": "3.3.0",
     "coveralls": "2.11.4",
-    "cracks": "3.1.0",
+    "cracks": "3.1.1",
     "istanbul-harmony": "0.3.16",
     "jsdoc": "3.3.3",
     "mocha": "2.3.3",


### PR DESCRIPTION
:rocket:

cracks just published version 3.1.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/semantic-release/cracks/releases/tag/v3.1.1)

<a name"3.1.1"></a>
### 3.1.1 (2015-10-07)


#### Bug Fixes

* **errors:** fix error messages by using actual template strings ([03097753](https://github.com/semantic-release/cracks/commit/03097753))

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [dd57a75](https://github.com/semantic-release/cracks/commit/dd57a753341b51a9870fc5b3ee1a70878fd1cb6d): Merge pull request #3 from marionebl/feat/error-loggin
- [0309775](https://github.com/semantic-release/cracks/commit/03097753ba419a0411a95d5395642fa209d96d90): fix(errors): fix error messages by using actual template strings

See the [full diff](https://github.com/semantic-release/cracks/compare/4e827ba135bd1bc2c2238f7a3755f8498abec53d...dd57a753341b51a9870fc5b3ee1a70878fd1cb6d).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>